### PR TITLE
Bump prettier version from 1.8.2 to 1.13.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "grunt-less-prettify"
   ],
   "dependencies": {
-    "prettier": "^1.8.2"
+    "prettier": "^1.13.7"
   }
 }

--- a/test/expected/different_extensions/.babelrc
+++ b/test/expected/different_extensions/.babelrc
@@ -1,1 +1,1 @@
-{ "plugins": ["transform-react-jsx"], "ignore": ["foo.js", "bar/**/*.js"] }
+{ plugins: ['transform-react-jsx'], ignore: ['foo.js', 'bar/**/*.js'] }


### PR DESCRIPTION
This PR merely bumps the version of the `prettier` dependency from 1.8.2 to 1.13.7, as it's been lagging for a few months now.
