### PR TITLE
adding support for the check and formatWithCursor api calls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,6 +92,15 @@ function tasks(grunt) {
           '!tmp/write_to_original_file_with_globe/*skip.js'
         ]
       },
+      write_to_original_file_to_check: {
+        src: ['tmp/formatted_write_to_original_file_to_check.js']
+      },
+      check_unformatted_file: {
+        src: [
+          'tmp/unformatted_write_to_original_file_to_check.js',
+          'tmp/formatted_write_to_original_file_to_check.js'
+        ]
+      },
       grunt_file: {
         src: ['Gruntfile.js', 'tasks/**.*', 'test/prettier_test.js']
       }
@@ -118,6 +127,29 @@ function tasks(grunt) {
             dest: 'tmp/write_to_original_file_with_globe/'
           }
         ]
+      },
+      write_to_original_file_to_check: {
+        files: {
+          'tmp/unformatted_write_to_original_file_to_check.js':
+            'test/fixtures/write_to_original_file/unformatted.js',
+          'tmp/formatted_write_to_original_file_to_check.js':
+            'test/expected/write_to_original_file/formatted.js'
+        }
+      },
+      check_unformatted_file: {
+        files: {
+          // just creating the folder and the empty file. Will be filled in once exec:quiet_prettier_check is run
+          'tmp/check_unformatted_file/results':
+            'test/fixtures/check_unformatted_file/results'
+        }
+      }
+    },
+    exec: {
+      quiet_prettier_check: {
+        command:
+          'grunt prettier:check_unformatted_file:check --force > tmp/check_unformatted_file/results',
+        stdout: true,
+        stderr: true
       }
     }
   });
@@ -129,10 +161,17 @@ function tasks(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-exec');
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'copy', 'prettier', 'nodeunit']);
+  grunt.registerTask('test', [
+    'clean',
+    'copy',
+    'exec:quiet_prettier_check',
+    'prettier',
+    'nodeunit'
+  ]);
 
   // By default, run all tests.
   grunt.registerTask('default', ['test']);

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ files: {
 }
 ```
 
+#### Testing
+To run unit tests
+```grunt test```
+
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-nodeunit": "^0.3.3"
+    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt-exec": "^3.0.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/prettier.js
+++ b/tasks/prettier.js
@@ -146,7 +146,7 @@ function prettierTask(grunt) {
         });
 
         if (!checkStatus) {
-          grunt.fail.warn('some files not pretty');
+          grunt.fail.warn('Some files are not pretty');
         }
       } else {
         // Else concat files and write to destination file.

--- a/tasks/prettier.js
+++ b/tasks/prettier.js
@@ -47,7 +47,9 @@ function getParser(file, defaultParser) {
 }
 
 function prettierTask(grunt) {
-  grunt.registerMultiTask('prettier', 'Prettier plugin for Grunt', function(api) {
+  grunt.registerMultiTask('prettier', 'Prettier plugin for Grunt', function(
+    api
+  ) {
     if (!api) {
       // default to format API if not specified
       api = 'format';
@@ -56,7 +58,7 @@ function prettierTask(grunt) {
     var supportedApis = ['check', 'format', 'formatWithCursor'];
 
     if (supportedApis.indexOf(api) < 0) {
-      grunt.log.warn('unsupported API')
+      grunt.log.warn('unsupported API');
       return false;
     }
 
@@ -86,8 +88,8 @@ function prettierTask(grunt) {
     if (fs.existsSync(prettierrcPath)) {
       grunt.verbose.writeln(`Using options from ${options.configFile}`);
       const prettierrcOptions = options.configFile.endsWith('.js')
-          ? require(options.configFile)
-          : grunt.file.readYAML(options.configFile);
+        ? require(options.configFile)
+        : grunt.file.readYAML(options.configFile);
       options = Object.assign({}, options, prettierrcOptions);
     }
     delete options.configFile;
@@ -144,7 +146,7 @@ function prettierTask(grunt) {
         });
 
         if (!checkStatus) {
-          grunt.fail.warn('some files not pretty')
+          grunt.fail.warn('some files not pretty');
         }
       } else {
         // Else concat files and write to destination file.

--- a/tasks/prettier.js
+++ b/tasks/prettier.js
@@ -9,21 +9,21 @@
 'use strict';
 
 const prettier = require('prettier'),
-    path = require('path'),
-    fs = require('fs'),
-    ProgressBar = require('progress');
+  path = require('path'),
+  fs = require('fs'),
+  ProgressBar = require('progress');
 
 let fileExtToParser = {};
 let fileNameToParser = {};
 prettier.getSupportInfo().languages.forEach(lang => {
   lang.extensions.forEach(extension => {
-  fileExtToParser[extension] = lang.parsers;
-});
-if (lang.filenames) {
-  lang.filenames.forEach(filename => {
-    fileNameToParser[filename] = lang.parsers;
-});
-}
+    fileExtToParser[extension] = lang.parsers;
+  });
+  if (lang.filenames) {
+    lang.filenames.forEach(filename => {
+      fileNameToParser[filename] = lang.parsers;
+    });
+  }
 });
 
 function getParser(file, defaultParser) {
@@ -31,16 +31,16 @@ function getParser(file, defaultParser) {
   let fileName = path.basename(file);
   if (fileExtToParser.hasOwnProperty(fileExt)) {
     let parser =
-        defaultParser in fileExtToParser[fileExt]
-            ? defaultParser
-            : fileExtToParser[fileExt][0];
+      defaultParser in fileExtToParser[fileExt]
+        ? defaultParser
+        : fileExtToParser[fileExt][0];
     return parser;
   }
   if (fileNameToParser.hasOwnProperty(fileName)) {
     let parser =
-        defaultParser in fileNameToParser[fileName]
-            ? defaultParser
-            : fileNameToParser[fileName][0];
+      defaultParser in fileNameToParser[fileName]
+        ? defaultParser
+        : fileNameToParser[fileName][0];
     return parser;
   }
   return defaultParser;
@@ -74,7 +74,8 @@ function prettierTask(grunt) {
       jsxBracketSameLine: false,
       parser: 'babylon',
       semi: true,
-      progress: false
+      progress: false,
+      cursorOffset: 1 // only for formatWithCursor
     });
 
     const progress = options.progress;
@@ -120,10 +121,10 @@ function prettierTask(grunt) {
         codeFiles.map(function(filepath) {
           unformattedCode = grunt.file.read(filepath);
           formattedCode = apiCall(
-              unformattedCode,
-              Object.assign({}, options, {
-                parser: getParser(filepath, options.parser)
-              })
+            unformattedCode,
+            Object.assign({}, options, {
+              parser: getParser(filepath, options.parser)
+            })
           );
           if (api === 'check') {
             // if we're just checking, output results to stdout, not the file
@@ -152,10 +153,10 @@ function prettierTask(grunt) {
         });
 
         formattedCode = apiCall(
-            unformattedCode.join(''),
-            Object.assign({}, options, {
-              parser: getParser(codeFiles[0], options.parser)
-            })
+          unformattedCode.join(''),
+          Object.assign({}, options, {
+            parser: getParser(codeFiles[0], options.parser)
+          })
         );
         grunt.file.write(f.dest, formattedCode);
         if (progress) {

--- a/test/expected/check_unformatted_file/results
+++ b/test/expected/check_unformatted_file/results
@@ -3,6 +3,6 @@ tmp/unformatted_write_to_original_file_to_check.js false
 Prettify file "tmp/unformatted_write_to_original_file_to_check.js".
 tmp/formatted_write_to_original_file_to_check.js true
 Prettify file "tmp/formatted_write_to_original_file_to_check.js".
-Warning: some files not pretty Used --force, continuing.
+Warning: Some files are not pretty Used --force, continuing.
 
 Done, but with warnings.

--- a/test/expected/check_unformatted_file/results
+++ b/test/expected/check_unformatted_file/results
@@ -1,0 +1,8 @@
+Running "prettier:check_unformatted_file:check" (prettier) task
+tmp/unformatted_write_to_original_file_to_check.js false
+Prettify file "tmp/unformatted_write_to_original_file_to_check.js".
+tmp/formatted_write_to_original_file_to_check.js true
+Prettify file "tmp/formatted_write_to_original_file_to_check.js".
+Warning: some files not pretty Used --force, continuing.
+
+Done, but with warnings.

--- a/test/prettier_test.js
+++ b/test/prettier_test.js
@@ -160,5 +160,24 @@ exports.prettier = {
     );
 
     test.done();
+  },
+
+  check_unformatted_files: function(test) {
+    test.expect(1);
+
+    let check_results_actual = grunt.file.read(
+      'tmp/check_unformatted_file/results'
+    );
+    let check_results_expected = grunt.file.read(
+      'test/expected/check_unformatted_file/results'
+    );
+
+    test.equal(
+      check_results_actual,
+      check_results_expected,
+      'Check results are not the same!'
+    );
+
+    test.done();
   }
 };


### PR DESCRIPTION
Honestly not too sure what the best approach for this should be, but given that it's a grunt task i figured it should just take a param. It should default to 'format' if are no params. I can write unit tests for this but wanted to put it up first to check the overall approach