### PR TITLE
Update default parser name

### DIFF
--- a/tasks/prettier.js
+++ b/tasks/prettier.js
@@ -74,7 +74,7 @@ function prettierTask(grunt) {
       trailingComma: 'none',
       bracketSpacing: true,
       jsxBracketSameLine: false,
-      parser: 'babylon',
+      parser: 'babel',
       semi: true,
       progress: false,
       cursorOffset: 1 // only for formatWithCursor


### PR DESCRIPTION
As of https://github.com/prettier/prettier/issues/4508 (PR: https://github.com/prettier/prettier/pull/5647) babel is the default parser and babylon is deprecated.